### PR TITLE
Adapt othello/default.nix for reflex-0-4

### DIFF
--- a/othello/default.nix
+++ b/othello/default.nix
@@ -1,10 +1,10 @@
 { mkDerivation, reflex, reflex-dom, file-embed, array, containers, split,
-  deepseq, transformers
+  deepseq, text, transformers
 }:
 
 mkDerivation {
-  pname = "peg-solitairec";
-  version = "0.1";
+  pname = "othello";
+  version = "0.1.1";
   src = builtins.filterSource (path: type: baseNameOf path != ".git") ./.;
   isExecutable = true;
   buildDepends = [
@@ -15,6 +15,7 @@ mkDerivation {
     reflex-dom
     file-embed
     deepseq
+    text
     transformers
   ];
   license = null;


### PR DESCRIPTION
Unfortunately, yesterday I missed to adapt the file othello/default.nix. I do not use *nix*, therefore I was not able to really test it! How do I specify, that it should use a version of reflex-dom >= 0.4 ?
Many thanks!
Roland