### PR TITLE
Set "draggable"="false" on peg solitaire pegs to prevent UI drags

### DIFF
--- a/frontend/src/Frontend/Examples/PegSolitaire/Main.hs
+++ b/frontend/src/Frontend/Examples/PegSolitaire/Main.hs
@@ -119,12 +119,16 @@ cell gs p = el "td" $ do
         | otherwise = no
       yes = "src"=: static @"peg-solitaire/images/ball.svg"
         <> "style" =: "display: block"
+        <> "draggable" =: "false"
       no  = "src"=: static @"peg-solitaire/images/square.svg"
         <> "style" =: "display: block"
+        <> "draggable" =: "false"
       idk = "src"=: static @"peg-solitaire/images/ball.svg"
         <> "style" =: "display: block; opacity: 0.35"
+        <> "draggable" =: "false"
       off = "src"=: "static/images/square.svg"
         <> "style" =: "display: block; opacity: 0"
+        <> "draggable" =: "false"
 
 -- | Row j of cells.
 row


### PR DESCRIPTION
This slightly improves the UX, since users can attempt to click-and-drag the peg solitaire pegs, but this doesn't allow user to make a move. Disabling draggable makes it more clear that user has to click in order to move.