### PR TITLE
Bumps reflex-dom to 0.5

### DIFF
--- a/.obelisk/impl/github.json
+++ b/.obelisk/impl/github.json
@@ -2,6 +2,6 @@
   "owner": "obsidiansystems",
   "repo": "obelisk",
   "branch": "master",
-  "rev": "ca6edae87909d0d3c31f6c4a89a2f70bcb209924",
-  "sha256": "1v40jv4zdvwnzv4113pi3sbfirgk1s2672slxzz4gq3ldkzphx7f"
+  "rev": "73bef50eca1c536817323453463f4422da9530ab",
+  "sha256": "1wqvzjwwm1qws4vg038pr6mwbhs2y9dblfz9cnvdpd8q6wg4jhmb"
 }

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -53,9 +53,7 @@ examples
      , PostBuild t m
      , MonadFix m
      , MonadHold t m
-     , PerformEvent t m
-     , TriggerEvent t m
-     , Prerender js m
+     , Prerender js t m
      )
   => Maybe Text
   -> Dynamic t (R Example)

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -37,7 +37,7 @@ import qualified Frontend.Examples.WebSocketChat.Main as WebSocketChat
 
 frontend :: Frontend (R FrontendRoute)
 frontend = Frontend
-  { _frontend_head = pageHead
+  { _frontend_head = prerender_ pageHead pageHead
   , _frontend_body = do
       r <- liftIO $ Cfg.get "config/common/route"
       el "header" $ nav

--- a/frontend/src/Frontend/Examples/ECharts/Main.hs
+++ b/frontend/src/Frontend/Examples/ECharts/Main.hs
@@ -34,18 +34,13 @@ import Language.Javascript.JSaddle hiding ((!!))
 import Reflex.Dom.Core
 
 app
-  :: forall t m js .
+  ::
      ( DomBuilder t m
-     , MonadFix m
-     , MonadHold t m
-     , PostBuild t m
-     , PerformEvent t m
-     , TriggerEvent t m
-     , Prerender js m
+     , Prerender js t m
      )
   => Maybe Text
   -> m ()
-app _ = prerender blank $ elAttr "div" ("style" =: "display: flex; flex-wrap: wrap") $ do
+app _ = prerender_ blank $ elAttr "div" ("style" =: "display: flex; flex-wrap: wrap") $ do
   delayedRender
     [ basicLineChart
     , cpuStatTimeLineChart
@@ -575,7 +570,7 @@ largeScaleAreaChart =
       , _chartOptions_tooltip = Just $ def
         { _toolTip_trigger = Just "axis"
         -- TODO
-        -- , _toolTip_pos = 
+        -- , _toolTip_pos =
         }
       , _chartOptions_toolbox = Just $ def
         { _toolBox_features =

--- a/frontend/src/Frontend/Examples/NasaPod/Main.hs
+++ b/frontend/src/Frontend/Examples/NasaPod/Main.hs
@@ -12,7 +12,6 @@ import qualified Data.Text                   as T
 import           Data.Text (Text)
 import           GHC.Generics                (Generic)
 import           Reflex.Dom
-import Control.Monad.Fix (MonadFix)
 
 data Apod =
   Apod { date           :: T.Text
@@ -30,12 +29,8 @@ instance ToJSON Apod
 
 app
   :: ( DomBuilder t m
-     , MonadFix m
      , MonadHold t m
-     , PostBuild t m
-     , PerformEvent t m
-     , TriggerEvent t m
-     , Prerender js m
+     , Prerender js t m
      )
   => m ()
 app = el "div" $ do
@@ -52,16 +47,11 @@ app = el "div" $ do
 
 apod
   :: ( DomBuilder t m
-     , MonadFix m
-     , PerformEvent t m
-     , MonadHold t m
-     , PostBuild t m
-     , TriggerEvent t m
-     , Prerender js m
+     , Prerender js t m
      )
   => Text
   -> m ()
-apod apiKey = prerender (blank) $ do
+apod apiKey = prerender_ (blank) $ do
   pb :: Event t () <- getPostBuild
   let
     defReq = "https://api.nasa.gov/planetary/apod?api_key=" <> apiKey
@@ -87,4 +77,3 @@ apod apiKey = prerender (blank) $ do
     el "p" $
       dynText =<< holdDyn "Waiting for response" explEv
   return ()
-

--- a/frontend/src/Frontend/Examples/WebSocketEcho/Main.hs
+++ b/frontend/src/Frontend/Examples/WebSocketEcho/Main.hs
@@ -4,6 +4,7 @@
 
 module Frontend.Examples.WebSocketEcho.Main where
 
+import           Control.Monad      (join)
 import           Data.Text.Encoding (encodeUtf8, decodeUtf8)
 import           Reflex.Dom         hiding (mainWidget)
 import           Reflex.Dom.Core    (mainWidget)
@@ -17,9 +18,7 @@ app
      , MonadFix m
      , MonadHold t m
      , PostBuild t m
-     , PerformEvent t m
-     , TriggerEvent t m
-     , Prerender js m
+     , Prerender js t m
      )
   => m ()
 app = do
@@ -30,7 +29,7 @@ app = do
             $ tag (current $ value t)
             $ leftmost [b, keypress Enter t]
 
-  receivedMessages <- prerender (return (constDyn [])) $ do
+  receivedMessages <- fmap join $ prerender (return (constDyn [])) $ do
     ws <- webSocket "wss://echo.websocket.org" $ def
       & webSocketConfig_send .~ newMessage
     foldDyn (\m ms -> ms ++ [m]) [] $ _webSocket_recv ws


### PR DESCRIPTION
This updates the examples for the new prerender structure. I cleaned up some warnings about redundant constraints along the way, but I can remove them if you like! 

The biggest annoyance is that any widget that cares about which DomBuilderSpace they are working in can only take concrete Elements if they are taking in an element since things didn't seem to line up well with the new `Client` type family. This has pushed the prerenders further up the widget tree and having bigger prerender blocks. 

Hopefully can someone can tell me the trick and tell me where I'm being silly with those and I'll fix them, because it seems like it should be the case that this kind of abstraction should be able to work in spite of the new types (seemingly) prohibiting it. 